### PR TITLE
Add Consul production domains to whitelist.

### DIFF
--- a/includes/redirect_whitelist.php
+++ b/includes/redirect_whitelist.php
@@ -6,6 +6,10 @@ function extend_allowed_domains_list($hosts)
 {
     $hosts[] = 'consul.staging.oecd.xapp.ovh';
     $hosts[] = 'consultation-staging.oecd-opsi.org';
+    $hosts[] = 'consul.production.oecd.xapp.ovh';
+    $hosts[] = 'engagement.oecd-opsi.org';
+    $hosts[] = 'www.consul.production.oecd.xapp.ovh';
+    $hosts[] = 'www.engagement.oecd-opsi.org';
     $hosts[] = 'lvh.me';
 
     return $hosts;


### PR DESCRIPTION
To make Consul redirection work in the production environment we need to add proper domains to the WP redirections whitelist.